### PR TITLE
Update necko.properties

### DIFF
--- a/es-MX/chrome/AB-CD/locale/AB-CD/necko/necko.properties
+++ b/es-MX/chrome/AB-CD/locale/AB-CD/necko/necko.properties
@@ -21,12 +21,12 @@
 27=prefijo no vinculado a un espacio de nombres
 28=no debe desdeclarar el prefijo
 
-UnsupportedFTPServer=El servidor FTP %1$S no está soportado actualmente.
+UnsupportedFTPServer=El protocolo del servidor FTP %1$S no es soportado en esta versión.
 RepostFormData=Esta página web está siendo redirigida a otra dirección. ¿Quieres reenviar los datos que ingresaste en el formulario a la nueva dirección?
 
 # Directory listing strings
 DirTitle=Índice de %1$S
-DirGoUp=Subir al directorio superior.
+DirGoUp=Subir al directorio superior
 ShowHidden=Mostrar objetos ocultos
 DirColName=Nombre
 DirColSize=Tamaño


### PR DESCRIPTION
UnsupportedFTPServer had a confusing expression. 

In my version I made stress about: Is the FTP protocol not the server per-se that is not supported, the previous writing looks like Pale Moon *bans* expressly the site for some unknown reason. And "esta versión" is just left the door open for future changes that may made the FTP server supported. More elegant.