### PR TITLE
Update AccessFu.properties

### DIFF
--- a/es-MX/chrome/AB-CD/locale/AB-CD/global/AccessFu.properties
+++ b/es-MX/chrome/AB-CD/locale/AB-CD/global/AccessFu.properties
@@ -76,9 +76,9 @@ textarea       =       área de texto
 headingLevel   =       encabezado de nivel %S
 
 # more sophisticated list announcement
-listStart      =       First item
-listEnd        =       Last item
-listItemCount  =       %S items
+listStart      =       Primer objeto
+listEnd        =       Último objeto
+listItemCount  =       %S objetos
 
 # Invoked actions
 jumpAction     =      saltado
@@ -110,29 +110,29 @@ stateCollapsed   =    colapsado
 stateUnavailable =    no disponible
 stateRequired    =    requerido
 stateTraversed   =    visitado
-stateHasPopup    =    has pop up
+stateHasPopup    =    tiene ventana emergente
 
 # App modes
-editingMode    =      editing
-navigationMode =      navigating
+editingMode    =      editar
+navigationMode =      navegar
 
 # Quick navigation modes
-quicknav_Simple      = Default
-quicknav_Anchor      = Anchors
-quicknav_Button      = Buttons
-quicknav_Combobox    = Combo boxes
-quicknav_Entry       = Entries
-quicknav_FormElement = Form elements
-quicknav_Graphic     = Images
-quicknav_Heading     = Headings
-quicknav_ListItem    = List items
-quicknav_Link        = Links
-quicknav_List        = Lists
-quicknav_PageTab     = Page tabs
-quicknav_RadioButton = Radio buttons
-quicknav_Separator   = Separators
-quicknav_Table       = Tables
-quicknav_Checkbox    = Check boxes
+quicknav_Simple      = Por defecto
+quicknav_Anchor      = Anclas
+quicknav_Button      = Botones
+quicknav_Combobox    = Cajas combo
+quicknav_Entry       = Entradas
+quicknav_FormElement = Elementos de Forma
+quicknav_Graphic     = Imágenes
+quicknav_Heading     = Cabeceras
+quicknav_ListItem    = Objetos de Lista
+quicknav_Link        = Enlaces
+quicknav_List        = Listas
+quicknav_PageTab     = Pestañas
+quicknav_RadioButton = Radio Botones
+quicknav_Separator   = Separadores
+quicknav_Table       = Tablas
+quicknav_Checkbox    = Casillas de verificación
 
 # Shortened role names for braille
 linkAbbr           =       lnk


### PR DESCRIPTION
Names for braille left unchanged because I do not know the short name conventions for my language. This can be left as is due the low usage of this feature.